### PR TITLE
Add missing rosinstall dependencies

### DIFF
--- a/robotsp.rosinstall
+++ b/robotsp.rosinstall
@@ -3,3 +3,5 @@
 # Dependencies
 - git: {local-name: raveutils, uri: 'https://github.com/crigroup/raveutils.git', version: master}
 - git: {local-name: openrave_catkin, uri: 'https://github.com/crigroup/openrave_catkin.git', version: master}
+- git: {local-name: criutils, uri: 'https://github.com/crigroup/criutils.git', version: master}
+- git: {local-name: lkh, uri: 'https://github.com/crigroup/lkh.git', version: master}


### PR DESCRIPTION
Requires extra repositories as dependencies: criutils and lkh 